### PR TITLE
[add] Configuración para enviar mensages a Dead

### DIFF
--- a/.env
+++ b/.env
@@ -9,3 +9,4 @@ TWILIO_ACCOUNT_SID=a
 TWILIO_ACCOUNT_TOKEN=b
 TWILIO_PHONE_NUMBER=c
 SCRAPPER_SERVICE=https://sms-scrapper.rover.quenecesito.org/sms
+RETRY_COUNT=3

--- a/workers/sms_request_worker.rb
+++ b/workers/sms_request_worker.rb
@@ -11,6 +11,7 @@ Sidekiq.configure_server do |config|
 end
 class SmsRequestWorker
   include Sidekiq::Worker
+  sidekiq_options :retry => ENV['RETRY_COUNT'].to_i
   
   def perform(sms_request_id)
     puts "::::::::::::::::::::::::::::::::::::::::::::::::::: Worker doing something \n"


### PR DESCRIPTION
El objetivo es sacar de la cola los posibles "mensajes enveneados", puede pensarse en hacer un handler para sacarlo de la tabla, en caso que el error sea temporal.